### PR TITLE
Refactory rust2018

### DIFF
--- a/chronicle-api/Cargo.toml
+++ b/chronicle-api/Cargo.toml
@@ -14,4 +14,3 @@ rand = "0.7.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 cdrs = "2.2.4"
-cdrs_helpers_derive = "0.1.0"

--- a/chronicle-api/src/api/api.rs
+++ b/chronicle-api/src/api/api.rs
@@ -1,5 +1,5 @@
+use chronicle_common::app;
 use tokio::sync::mpsc;
-
 app!(ApiBuilder { listen_address: String });
 
 impl ApiBuilder {

--- a/chronicle-api/src/api/endpoint.rs
+++ b/chronicle-api/src/api/endpoint.rs
@@ -1,4 +1,5 @@
 use super::router::handle;
+use chronicle_common::actor;
 use hyper::{
     server::Server,
     service::{
@@ -10,7 +11,6 @@ use std::{
     convert::Infallible,
     net::SocketAddr,
 };
-
 actor!(ServerBuilder { listen_address: String });
 
 impl ServerBuilder {

--- a/chronicle-api/src/api/gettrytes.rs
+++ b/chronicle-api/src/api/gettrytes.rs
@@ -9,7 +9,11 @@ use cdrs::{
     query::QueryFlags,
     query_values,
 };
-use chronicle_common::statements::statements::SELECT_TX_QUERY;
+use chronicle_common::{
+    actor,
+    app,
+    statements::statements::SELECT_TX_QUERY,
+};
 use chronicle_cql::frame::{
     decoder::Decoder,
     frame::Frame,
@@ -29,7 +33,6 @@ use hyper::{
 use serde::Serialize;
 use serde_json::Value;
 use tokio::sync::mpsc;
-
 type Sender = mpsc::UnboundedSender<Event>;
 type Receiver = mpsc::UnboundedReceiver<Event>;
 #[derive(Debug)]

--- a/chronicle-api/src/lib.rs
+++ b/chronicle-api/src/lib.rs
@@ -1,5 +1,1 @@
 pub mod api;
-#[macro_use]
-extern crate chronicle_common;
-#[macro_use]
-extern crate cdrs_helpers_derive;

--- a/chronicle-cql/benches/murmur3_benchmark.rs
+++ b/chronicle-cql/benches/murmur3_benchmark.rs
@@ -1,7 +1,9 @@
-#[macro_use]
-extern crate criterion;
 use chronicle_cql::murmur3::murmur3::murmur3_cassandra_x64_128;
-use criterion::Criterion;
+use criterion::{
+    criterion_group,
+    criterion_main,
+    Criterion,
+};
 use std::io::Cursor;
 
 fn tx_murmur3_cassandra_x64_128() {

--- a/chronicle-storage/src/cluster/supervisor.rs
+++ b/chronicle-storage/src/cluster/supervisor.rs
@@ -20,12 +20,12 @@ use crate::{
         DC,
     },
 };
+use chronicle_common::actor;
 use std::{
     collections::HashMap,
     sync::Arc,
 };
 use tokio::sync::mpsc;
-
 //types
 pub type Sender = mpsc::UnboundedSender<Event>;
 pub type Receiver = mpsc::UnboundedReceiver<Event>;

--- a/chronicle-storage/src/connection/cql.rs
+++ b/chronicle-storage/src/connection/cql.rs
@@ -45,6 +45,11 @@ use tokio::{
     prelude::*,
 };
 
+use cdrs_helpers_derive::{
+    IntoCDRSValue,
+    TryFromRow,
+};
+
 pub type Address = String;
 
 #[derive(Debug)]

--- a/chronicle-storage/src/dashboard/dashboard.rs
+++ b/chronicle-storage/src/dashboard/dashboard.rs
@@ -4,6 +4,7 @@ use crate::{
     cluster::supervisor,
     connection::cql::Address,
 };
+use chronicle_common::actor;
 use futures::stream::SplitSink;
 use std::{
     collections::HashMap,

--- a/chronicle-storage/src/dashboard/listener.rs
+++ b/chronicle-storage/src/dashboard/listener.rs
@@ -3,9 +3,9 @@ use super::{
     dashboard,
     websocket,
 };
+use chronicle_common::actor;
 use tokio::net::TcpListener;
 use tokio_tungstenite::accept_async;
-
 // types
 
 actor!(ListenerBuilder {

--- a/chronicle-storage/src/dashboard/websocket.rs
+++ b/chronicle-storage/src/dashboard/websocket.rs
@@ -5,6 +5,7 @@
 
 // uses
 use super::dashboard;
+use chronicle_common::actor;
 use futures::{
     stream::{
         SplitSink,

--- a/chronicle-storage/src/engine/engine.rs
+++ b/chronicle-storage/src/engine/engine.rs
@@ -5,6 +5,7 @@ use crate::{
     dashboard::dashboard,
     ring::ring::DC,
 };
+use chronicle_common::app;
 use tokio::sync::mpsc;
 
 type ThreadCount = usize;

--- a/chronicle-storage/src/engine/helper.rs
+++ b/chronicle-storage/src/engine/helper.rs
@@ -1,8 +1,8 @@
 // helper for unit test and not for production,
 // production setup should manage and setup everything through dashboard. therefore this mod will be removed eventually once we have dashboard ready.
 use crate::dashboard::dashboard;
+use chronicle_common::actor;
 use std::time::Duration;
-
 actor!(
     HelperBuilder {
         nodes: Vec<String>,

--- a/chronicle-storage/src/stage/receiver.rs
+++ b/chronicle-storage/src/stage/receiver.rs
@@ -4,12 +4,12 @@ use super::{
     reporter::Stream,
     supervisor,
 };
+use chronicle_common::actor;
 use tokio::{
     io::ReadHalf,
     net::TcpStream,
     prelude::*,
 };
-
 // consts
 const HEADER_LENGTH: usize = 9;
 

--- a/chronicle-storage/src/stage/reporter.rs
+++ b/chronicle-storage/src/stage/reporter.rs
@@ -9,6 +9,7 @@ use crate::worker::{
     Error,
     Worker,
 };
+use chronicle_common::actor;
 use std::{
     collections::HashMap,
     io::{
@@ -17,7 +18,6 @@ use std::{
     },
 };
 use tokio::sync::mpsc;
-
 // types
 pub type Sender = mpsc::UnboundedSender<Event>;
 type Receiver = mpsc::UnboundedReceiver<Event>;

--- a/chronicle-storage/src/stage/sender.rs
+++ b/chronicle-storage/src/stage/sender.rs
@@ -5,13 +5,13 @@ use super::{
     supervisor,
 };
 use crate::stage::reporter::Stream;
+use chronicle_common::actor;
 use tokio::{
     io::WriteHalf,
     net::TcpStream,
     prelude::*,
     sync::mpsc,
 };
-
 // types
 pub type Sender = mpsc::UnboundedSender<Stream>;
 pub type Receiver = mpsc::UnboundedReceiver<Stream>;

--- a/chronicle-storage/src/stage/supervisor.rs
+++ b/chronicle-storage/src/stage/supervisor.rs
@@ -11,6 +11,7 @@ use crate::{
         Streams,
     },
 };
+use chronicle_common::actor;
 use std::{
     cell::UnsafeCell,
     collections::HashMap,
@@ -21,7 +22,6 @@ use tokio::{
     sync::mpsc,
     time::delay_for,
 };
-
 pub type Sender = mpsc::UnboundedSender<Event>;
 pub type Receiver = mpsc::UnboundedReceiver<Event>;
 pub type Reporters = HashMap<u8, mpsc::UnboundedSender<reporter::Event>>;


### PR DESCRIPTION
- Remove 'extern crate' by following Rust 2018-edition style