### PR TITLE
Starter errors

### DIFF
--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use async_trait::async_trait;
 use chronicle::*;
 
@@ -53,7 +55,7 @@ impl Shutdown for HelloWorldSender {
 #[async_trait]
 impl<H: LauncherSender<Self>> Starter<H> for HelloWorldBuilder<H> {
     type Ok = HelloWorldSender;
-    type Error = ();
+    type Error = Cow<'static, str>;
     // if application asked for Need::Restart or RescheduleAfter then the input will hold the prev app From::from(state)
     type Input = HelloWorld;
     async fn starter(mut self, handle: H, mut _input: Option<Self::Input>) -> Result<Self::Ok, Self::Error> {

--- a/examples/two_apps.rs
+++ b/examples/two_apps.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 //////////////////////////////// HelloWorld App ////////////////////////////////////////////
 use async_trait::async_trait;
 use chronicle::*;
@@ -54,7 +56,7 @@ impl Shutdown for HelloWorldSender {
 #[async_trait]
 impl<H: LauncherSender<Self>> Starter<H> for HelloWorldBuilder {
     type Ok = HelloWorldSender;
-    type Error = ();
+    type Error = Cow<'static, str>;
     // if application asked for Need::Restart or RescheduleAfter then the input will hold the prev app From::from(state)
     type Input = HelloWorld;
     async fn starter(mut self, handle: H, mut _input: Option<Self::Input>) -> Result<Self::Ok, Self::Error> {
@@ -202,7 +204,7 @@ impl Shutdown for HowdySender {
 #[async_trait]
 impl<H: LauncherSender<HowdyBuilder>> Starter<H> for HowdyBuilder {
     type Ok = HowdySender;
-    type Error = ();
+    type Error = Cow<'static, str>;
     // if application asked for Need::Restart or RescheduleAfter then the input will hold the prev app From::from(state)
     type Input = Howdy;
     async fn starter(mut self, handle: H, mut _input: Option<Self::Input>) -> Result<Self::Ok, Self::Error> {

--- a/src/actor/launcher.rs
+++ b/src/actor/launcher.rs
@@ -381,12 +381,12 @@ macro_rules! launcher {
                             self.service.update_microservice(app_name, service);
                             info!("Succesfully starting {}", stringify!($app));
                         }
-                        Err(_) => {
+                        Err(e) => {
                             // create new service that indicates the app is stopped
                             let service = Service::new().set_status(ServiceStatus::Stopped).set_name(app_name.clone());
                             // update main service
                             self.service.update_microservice(app_name, service);
-                            error!("unable to start {}", stringify!($app));
+                            error!("Unable to start {}: {}", stringify!($app), e.to_string());
                         }
                     }
                     self

--- a/src/actor/launcher.rs
+++ b/src/actor/launcher.rs
@@ -386,7 +386,7 @@ macro_rules! launcher {
                             let service = Service::new().set_status(ServiceStatus::Stopped).set_name(app_name.clone());
                             // update main service
                             self.service.update_microservice(app_name, service);
-                            error!("Unable to start {}: {}", stringify!($app), e.to_string());
+                            error!("Unable to start {}: {}", stringify!($app), e);
                         }
                     }
                     self

--- a/src/actor/mod.rs
+++ b/src/actor/mod.rs
@@ -14,9 +14,7 @@ pub use supervisor::*;
 pub use terminating::Terminating;
 
 #[async_trait]
-pub trait Actor<H: AknShutdown<Self> + 'static>: StartActor<H> + Name {
-    
-}
+pub trait Actor<H: AknShutdown<Self> + 'static>: StartActor<H> + Name {}
 
 impl<T: super::Name + super::EventLoop<H> + super::Init<H> + super::Terminating<H>, H: Send + 'static + AknShutdown<Self>> Actor<H> for T {}
 

--- a/src/actor/starter.rs
+++ b/src/actor/starter.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 #[async_trait]
 pub trait Starter<H> {
     type Ok;
-    type Error;
+    type Error: std::fmt::Display;
     type Input;
     async fn starter(self, handle: H, input: Option<Self::Input>) -> Result<Self::Ok, Self::Error>;
 }


### PR DESCRIPTION
Allow the `Starter` trait to define printable errors which the `launcher!` macro can output in case of a failure at startup.