### PR TITLE
Add analytics calculation method

### DIFF
--- a/chronicle-broker/src/types.rs
+++ b/chronicle-broker/src/types.rs
@@ -15,7 +15,10 @@ use serde::{
 };
 use std::{
     collections::HashMap,
-    ops::Range,
+    ops::{
+        Add,
+        Range,
+    },
     path::PathBuf,
 };
 use url::Url;
@@ -85,9 +88,9 @@ pub struct MilestoneData {
 /// The analytics collected from the milestone data
 pub struct Analytics {
     /// The transaction count
-    pub transaction_count: u128,
+    pub transaction_count: u64,
     /// The message count
-    pub message_count: u128,
+    pub message_count: u64,
     /// The transferred tokens
     pub transferred_tokens: u128,
 }
@@ -121,9 +124,9 @@ impl MilestoneData {
     /// Get the analytics from the collected messages
     pub fn get_analytics(&self) -> Analytics {
         // The accumulators
-        let mut transaction_count: u128 = 0;
-        let mut message_count: u128 = 0;
-        let mut transferred_tokens: u128 = 0;
+        let mut transaction_count: u64 = 0;
+        let mut message_count: u64 = 0;
+        let mut transferred_tokens: u64 = 0;
 
         // Iterate the messages to calculate analytics
         for (_, full_message) in &self.messages {

--- a/chronicle-broker/src/types.rs
+++ b/chronicle-broker/src/types.rs
@@ -1,5 +1,10 @@
 use bee_message::{
-    prelude::MilestonePayload,
+    prelude::{
+        Essence,
+        MilestonePayload,
+        Output,
+        Payload,
+    },
     Message,
     MessageId,
 };
@@ -76,6 +81,29 @@ pub struct MilestoneData {
     pub(crate) created_by: CreatedBy,
 }
 
+#[derive(Deserialize, Serialize)]
+/// The analytics collected from the milestone data
+pub struct Analytics {
+    /// The transaction count
+    pub transaction_count: u128,
+    /// The message count
+    pub message_count: u128,
+    /// The transferred tokens
+    pub transferred_tokens: u128,
+}
+
+impl Add for Analytics {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self {
+            transaction_count: self.transaction_count + other.transaction_count,
+            message_count: self.message_count + other.message_count,
+            transferred_tokens: self.transferred_tokens + other.transferred_tokens,
+        }
+    }
+}
+
 impl MilestoneData {
     pub(crate) fn new(milestone_index: u32, created_by: CreatedBy) -> Self {
         Self {
@@ -89,6 +117,46 @@ impl MilestoneData {
     /// Get the milestone index from this milestone data
     pub fn milestone_index(&self) -> u32 {
         self.milestone_index
+    }
+    /// Get the analytics from the collected messages
+    pub fn get_analytics(&self) -> Analytics {
+        // The accumulators
+        let mut transaction_count: u128 = 0;
+        let mut message_count: u128 = 0;
+        let mut transferred_tokens: u128 = 0;
+
+        // Iterate the messages to calculate analytics
+        for (_, full_message) in &self.messages {
+            // Accumulate the message count
+            message_count += 1;
+            if let Some(Payload::Transaction(payload)) = full_message.message().payload() {
+                // Accumulate the transaction count
+                transaction_count += 1;
+                if let Essence::Regular(regular_essence) = payload.essence() {
+                    for output in regular_essence.outputs() {
+                        match output {
+                            // Accumulate the transferred token amount
+                            Output::SignatureLockedSingle(output) => transferred_tokens += output.amount() as u128,
+                            Output::SignatureLockedDustAllowance(output) => {
+                                transferred_tokens += output.amount() as u128
+                            }
+                            // Note that the transaction payload don't have Treasury
+                            _ => unreachable!(),
+                        }
+                    }
+                } else {
+                    // There is only one kind of essence currently
+                    unreachable!();
+                }
+            }
+        }
+
+        // Return the analytics
+        Analytics {
+            transaction_count,
+            message_count,
+            transferred_tokens,
+        }
     }
     pub(crate) fn set_milestone(&mut self, boxed_milestone_payload: Box<MilestonePayload>) {
         self.milestone.replace(boxed_milestone_payload);

--- a/chronicle-broker/src/types.rs
+++ b/chronicle-broker/src/types.rs
@@ -126,7 +126,7 @@ impl MilestoneData {
         // The accumulators
         let mut transaction_count: u64 = 0;
         let mut message_count: u64 = 0;
-        let mut transferred_tokens: u64 = 0;
+        let mut transferred_tokens: u128 = 0;
 
         // Iterate the messages to calculate analytics
         for (_, full_message) in &self.messages {


### PR DESCRIPTION
Add the method to get the analytics and the related structures/traits.

The `get_analytics()` is a method associated with `MilestoneData`, which is used to get the `Analytics` in the associated milestone.

The `Analytics` struct is used to records the statistics, and the `Add` trait is also implemented to facilitate the accumulation in different `Analytics` structures.

```rust
pub struct Analytics {
    pub transaction_count: u64,
    pub message_count: u64,
    pub transferred_tokens: u128,
}
