### PR TITLE
Fix links in documentation

### DIFF
--- a/documentation/docs/config_reference.md
+++ b/documentation/docs/config_reference.md
@@ -3,7 +3,7 @@
 ## `storage_config`
 
 ### `keyspaces: Vec<KeyspaceConfig>`
-See [KeyspaceConfig](chronicle-storage/src/config.rs#KeyspaceConfig)
+See [KeyspaceConfig](https://github.com/iotaledger/chronicle.rs/blob/a9cfc14289d970251eea6f1e501686d655e2742f/chronicle-common/src/config/storage.rs#L93-L98)
 
 Multiple keyspaces can be configured in order to filter incoming messages. If the `filter` feature is not used, *only the first configured keyspace will be considered* or the default (`chronicle`) if none is provided.
 
@@ -22,7 +22,7 @@ The number of reporters Scylla will spawn.
 The Scylla local datacenter.
 
 ### `partition_config`
-See [PartitionConfig](chronicle-storage/src/config.rs#PartitionConfig)
+See [PartitionConfig](https://github.com/iotaledger/chronicle.rs/blob/a9cfc14289d970251eea6f1e501686d655e2742f/chronicle-common/src/config/storage.rs#L138-L143)
 
 Specifies the number of partitions to use in the database, as well as the number of milestones to use as chunks.
 

--- a/documentation/docs/config_reference.md
+++ b/documentation/docs/config_reference.md
@@ -30,7 +30,7 @@ NOTICE: You can't change `partition_config` in future without migration.
 
 ## `api_config`
 
-Nothing at the moment, please refer to [.env](.env).
+Nothing at the moment, please refer to [.env](https://github.com/iotaledger/chronicle.rs/blob/main/.env).
 
 ## `broker_config`
 

--- a/documentation/docs/getting_started.md
+++ b/documentation/docs/getting_started.md
@@ -55,7 +55,7 @@ git clone https://github.com/iotaledger/chronicle.rs
 cargo build --release
 ```
 
-If you wish to use the filter functionality, enable the `filter` feature in [chronicle](chronicle/Cargo.toml)
+If you wish to use the filter functionality, enable the `filter` feature in [chronicle](https://github.com/iotaledger/chronicle.rs/blob/main/Cargo.toml)
 
 ```bash
 cargo build --release --features filter
@@ -63,7 +63,7 @@ cargo build --release --features filter
 
 ### Configuring Chronicle
 
-Chronicle uses a [RON](https://github.com/ron-rs/ron) file to store configuration parameters, called `config.ron`. An example is provided as [config.example.ron](config.example.ron) with default values. See <a href="#config-reference">Config Reference</a> for more details about the config file.
+Chronicle uses a [RON](https://github.com/ron-rs/ron) file to store configuration parameters, called `config.ron`. An example is provided as [config.example.ron](https://github.com/iotaledger/chronicle.rs/blob/main/config.example.ron) with default values. See <a href="#config-reference">Config Reference</a> for more details about the config file.
 
 ### Running Chronicle
 


### PR DESCRIPTION
I'm not quite sure to what the links in the documentation should link to, but I tried to fix them so that the wiki doesn't complain about broken links :)