### PR TITLE
Use chronicle path to be compatible with other versions

### DIFF
--- a/documentation/docusaurus.config.js
+++ b/documentation/docusaurus.config.js
@@ -7,10 +7,16 @@ module.exports = {
             {
                 id: 'chronicle-rs',
                 path: path.resolve(__dirname, 'docs'),
-                routeBasePath: 'chronicle.rs',
+                routeBasePath: 'chronicle',
                 sidebarPath: path.resolve(__dirname, 'sidebars.js'),
                 editUrl: 'https://github.com/iotaledger/chronicle.rs/edit/main/documentation',
                 remarkPlugins: [require('remark-code-import'), require('remark-import-partial')],
+                versions: {
+                    current: {
+                        label: 'IOTA',
+                        badge: true
+                    },
+                },
             }
         ],
     ],


### PR DESCRIPTION
We need to use the same subpath in all versions so that the wiki can determine the existing versions